### PR TITLE
Fix for -d option

### DIFF
--- a/recoverjpeg.c
+++ b/recoverjpeg.c
@@ -182,7 +182,7 @@ file_name(const char *dir_format, const char *file_format, unsigned int index)
 
   if (dir_format) {
     snprintf(dir_buffer, sizeof dir_buffer, dir_format, index / 100);
-    if (mkdir(dir_buffer, 0777) == -1) {
+    if (access(dir_buffer, F_OK) == -1 && mkdir(dir_buffer, 0777) == -1) {
       fprintf(stderr,
 	      "recoverjpeg: unable to create directory %s (%s)\n",
 	      dir_buffer, strerror(errno));


### PR DESCRIPTION
I ran into the problem, that the -d option (e.g. `recoverjpeg -d "%05d" test.img`) was not working on my system (Debian & cygwin). I always got this error message: `recoverjpeg: unable to create directory 00000 (17 (File exists))`. That's because recoverjpeg wants to create the directory regardless whether it was already created before or not.

I've added a check in line 185; the directory is now created only when the directory does not exist.

This fixed the issue and recoverjpeg was able to recover over 195.000 files from an image of a broken hard disk :-)

I've tested the code on Debian 6.0.6 and cygwin 1.7.17 and it worked on both systems.
