### PR TITLE
Provide 'make clean' and 'make distclean'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,2 +1,13 @@
 AUTOMAKE_OPTIONS = foreign
 SUBDIRS = src doc scripts tests
+
+clean-local:
+	rm -f doc/*.1
+
+distclean-local:
+	rm -rf autom4te.cache
+	rm -f aclocal.m4 config.h.* configure Makefile.in
+	rm -f doc/Makefile.in scripts/Makefile.in src/Makefile.in \
+              tests/Makefile.in
+	rm -f support/compile support/depcomp support/install-sh \
+              support/missing support/test-driver


### PR DESCRIPTION
Hi Samuel,

In Debian, the 2.6.1 version does not build twice because the files doc/*.1 are not removed between rebuilds. So, I am suggesting this patch (pull request) to fix the 'make clean' and 'make distclean' commands.

If needed, as reference, you can read it[1].

[1] https://www.gnu.org/software/automake/manual/html_node/Extending.html#Extending

Thanks in advance.

Regards,

Eriberto
